### PR TITLE
Configure db via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Database connection settings
+DB_HOST=localhost
+DB_USER=username
+DB_PASS=password
+DB_NAME=mydatabase

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+.env
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, copy `.env.example` to `.env` and update the values with your database credentials:
+
+```bash
+cp .env.example .env
+```
+
+Then run the development server:
 
 ```bash
 npm run dev

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,10 +2,10 @@ import mysql from "mysql2/promise";
 
 export async function getConnection() {
   const connection = await mysql.createConnection({
-  host: "strofeheikonk.beget.app",
-  user: "cyberfootball",
-  password: "Acfdatabase2233!",
-  database: "cyberfootball",
+    host: process.env.DB_HOST!,
+    user: process.env.DB_USER!,
+    password: process.env.DB_PASS!,
+    database: process.env.DB_NAME!,
   });
 
   return connection;


### PR DESCRIPTION
## Summary
- add `.env.example` with database config
- ignore `.env` but allow `.env.example`
- read DB settings from environment variables
- update README to describe copying `.env.example`

## Testing
- `npm install`
- `npm run lint` *(fails: 'getConnection' is defined but never used in src/app/players/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6840dcd3ee0483268b302c44e41678ec